### PR TITLE
Fix overly restrictive dialyzer typespecs

### DIFF
--- a/lib/tipalti/api/payer.ex
+++ b/lib/tipalti/api/payer.ex
@@ -82,11 +82,11 @@ defmodule Tipalti.API.Payer do
   An invoice, used when creating invoices in `create_or_update_invoices/1`.
   """
   @type invoice :: %{
-          required(:can_approve) => boolean(),
           required(:date) => String.t(),
           required(:idap) => Tipalti.idap(),
-          required(:is_paid_manually) => boolean(),
           required(:subject) => String.t(),
+          optional(:can_approve) => boolean(),
+          optional(:is_paid_manually) => boolean(),
           optional(:ap_account_number) => String.t(),
           optional(:approvers) => [invoice_approver()],
           optional(:currency) => String.t(),

--- a/lib/tipalti/iframe/setup_process.ex
+++ b/lib/tipalti/iframe/setup_process.ex
@@ -56,20 +56,20 @@ defmodule Tipalti.IFrame.SetupProcess do
   """
   @type t :: %__MODULE__{
           idap: Tipalti.idap(),
-          country: String.t(),
-          first: String.t(),
-          middle: String.t(),
-          last: String.t(),
-          company: String.t(),
-          uiculture: String.t(),
-          street1: String.t(),
-          street2: String.t(),
-          city: String.t(),
-          zip: String.t(),
-          state: String.t(),
-          alias: String.t(),
-          email: String.t(),
-          preferred_payer_entity: String.t()
+          country: String.t() | nil,
+          first: String.t() | nil,
+          middle: String.t() | nil,
+          last: String.t() | nil,
+          company: String.t() | nil,
+          uiculture: String.t() | nil,
+          street1: String.t() | nil,
+          street2: String.t() | nil,
+          city: String.t() | nil,
+          zip: String.t() | nil,
+          state: String.t() | nil,
+          alias: String.t() | nil,
+          email: String.t() | nil,
+          preferred_payer_entity: String.t() | nil
         }
 
   @enforce_keys [:idap]


### PR DESCRIPTION
This PR relaxes some restrictions in typespecs for use cases that are allowed by the tipalti client.