### PR TITLE
Adds Telemetry Tesla Midleware to SOAP Client and IPN Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - No changes
 
+## [0.11.0][]- 2024-05-14
+
+### Updated
+
+- Adds Tesla telemetry Plug to collect metrics
+
 ## [0.10.0][]
 
 ### Fixed

--- a/lib/tipalti/api/soap/client.ex
+++ b/lib/tipalti/api/soap/client.ex
@@ -10,6 +10,7 @@ defmodule Tipalti.API.SOAP.Client do
   adapter Tesla.Adapter.Hackney, recv_timeout: Application.get_env(:tipalti, :client_recv_timeout, 60_000)
 
   plug Tesla.Middleware.Headers, [{"Content-Type", "application/soap+xml; charset=utf-8"}]
+  plug Tesla.Middleware.Telemetry
 
   @spec send(Keyword.t(), String.t()) :: {:ok, String.t()} | {:error, RequestError.t()}
   def send(base_urls, payload) do

--- a/lib/tipalti/ipn/client.ex
+++ b/lib/tipalti/ipn/client.ex
@@ -16,6 +16,7 @@ defmodule Tipalti.IPN.Client do
   adapter Tesla.Adapter.Hackney, recv_timeout: Application.get_env(:tipalti, :client_recv_timeout, 60_000)
 
   plug Tesla.Middleware.Headers, [{"Content-Type", "application/x-www-form-urlencoded"}]
+  plug Tesla.Middleware.Telemetry
 
   @url [
     sandbox: "https://console.sandbox.tipalti.com/notif/ipn.aspx",

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tipalti.MixProject do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.11.0"
 
   def project do
     [


### PR DESCRIPTION
Plug a [Tesla Telemetry Middleware](https://hexdocs.pm/tesla/Tesla.Middleware.Telemetry.html) to `Tipalti.API.SOAP.Client` and `Tipalti.IPN.Client` to emit request response metrics. 

An example of how to start collecting emitted events:
```
:telemetry.attach(
  "tipalti-client-telemetry",
  [:tesla, :request, :stop],
  fn event, measurements, meta, config ->
    # Do something with the event
  end,
  nil
)
```