### PR TITLE
Update payer V5 API to match the Tipalti specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
+
+- No changes
+
+## [0.10.0][]
+
 ### Fixed
 
 - Make `can_approve` and `is_paid_manually` fields from Payer API required to match Tipalti specification
@@ -127,7 +132,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Initial release
 
-[Unreleased]: https://github.com/peek-travel/tipalti-elixir/compare/0.9.0...HEAD
+[Unreleased]: https://github.com/peek-travel/tipalti-elixir/compare/0.10.0...HEAD
+
+[0.10.0]: https://github.com/peek-travel/tipalti-elixir/compare/0.9.0...0.10.0
 
 [0.9.0]: https://github.com/peek-travel/tipalti-elixir/compare/0.8.6...0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased][]
+### Fixed
 
+- Make `can_approve` and `is_paid_manually` fields from Payer API required to match Tipalti specification
+
+### Updated
+
+- Updates on Tipalti documentation urls
 ## [0.9.0][] - 2021-05-20
 
 ### Updated

--- a/lib/tipalti/api/payer.ex
+++ b/lib/tipalti/api/payer.ex
@@ -84,8 +84,8 @@ defmodule Tipalti.API.Payer do
           required(:date) => String.t(),
           required(:idap) => Tipalti.idap(),
           required(:subject) => String.t(),
-          optional(:can_approve) => boolean(),
-          optional(:is_paid_manually) => boolean(),
+          required(:can_approve) => boolean(),
+          required(:is_paid_manually) => boolean(),
           optional(:ap_account_number) => String.t(),
           optional(:approvers) => [invoice_approver()],
           optional(:currency) => String.t(),
@@ -107,7 +107,7 @@ defmodule Tipalti.API.Payer do
   Returns a list of invoice responses for each invoice,
   indicating if it succeeded and what the errors were if it didn't.
 
-  See <https://support.tipalti.com/Content/Topics/Development/APIs/PayerApi.htm> for details.
+  See <https://support.tipalti.com/Content/Topics/Development/APIs/PayeeAPI/Intro.htm> for details.
 
   ## Parameters
 
@@ -155,7 +155,7 @@ defmodule Tipalti.API.Payer do
 
   ## Examples
 
-      iex> create_or_update_invoices([%{idap: "somepayee", ref_code: "testinvoice1", due_date: "2018-05-01", date: "2018-06-01", subject: "test invoice 1", currency: "USD", line_items: [%{amount: "100.00", description: "test line item"}]}, %{idap: "somepayee", ref_code: "testinvoice2", due_date: "2018-06-01", date: "2018-05-01", subject: "test invoice 2", currency: "USD", line_items: [%{amount: "100.00", description: "test line item"}]}])
+      iex> create_or_update_invoices([%{idap: "somepayee", can_approve: false, is_paid_manually: false, ref_code: "testinvoice1", due_date: "2018-05-01", date: "2018-06-01", subject: "test invoice 1", currency: "USD", line_items: [%{amount: "100.00", description: "test line item"}]}, %{idap: "somepayee", ref_code: "testinvoice2", due_date: "2018-06-01", date: "2018-05-01", subject: "test invoice 2", currency: "USD", line_items: [%{amount: "100.00", description: "test line item"}]}])
       {:ok,
       [
         %{
@@ -173,7 +173,7 @@ defmodule Tipalti.API.Payer do
       iex> custom_fields = [%{key: "foo", value: "bar"}]
       ...> line_items = [%{amount: "100.00", description: "test line item", custom_fields: custom_fields}]
       ...> approvers = [%{name: "Mr. Approver", email: "approver@example.com", order: 1}]
-      ...> invoice = %{idap: "somepayee", ref_code: "testinvoice", due_date: "2018-06-01", date: "2018-05-01", subject: "test invoice", currency: "USD", line_items: line_items, custom_fields: custom_fields, approvers: approvers}
+      ...> invoice = %{idap: "somepayee", can_approve: false, is_paid_manually: false, ref_code: "testinvoice", due_date: "2018-06-01", date: "2018-05-01", subject: "test invoice", currency: "USD", line_items: line_items, custom_fields: custom_fields, approvers: approvers}
       ...> create_or_update_invoices([invoice])
       {:ok, [%{error_message: nil, ref_code: "testinvoice", succeeded: true}]}
   """

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Tipalti.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.10.0"
 
   def project do
     [

--- a/test/requests/create_or_update_invoices_custom_req.xml
+++ b/test/requests/create_or_update_invoices_custom_req.xml
@@ -23,12 +23,14 @@
               </CustomFields>
             </InvoiceLine>
           </InvoiceLines>
+          <CanApprove>false</CanApprove>
           <CustomFields>
             <KeyValuePair>
               <Key>foo</Key>
               <Value>bar</Value>
             </KeyValuePair>
           </CustomFields>
+          <IsPaidManually>false</IsPaidManually>
           <Currency>USD</Currency>
           <Approvers>
             <TipaltiInvoiceApprover>

--- a/test/requests/create_or_update_invoices_req.xml
+++ b/test/requests/create_or_update_invoices_req.xml
@@ -17,6 +17,8 @@
               <Description>test line item</Description>
             </InvoiceLine>
           </InvoiceLines>
+          <CanApprove>false</CanApprove>
+          <IsPaidManually>false</IsPaidManually>
           <Currency>USD</Currency>
           <InvoiceSubject>test invoice 1</InvoiceSubject>
         </TipaltiInvoiceItemRequest>


### PR DESCRIPTION

### This PR aims to update payer V5 API to match the Tipalti specification


```xml
<s:element minOccurs="1" maxOccurs="1" name="IsPaidManually" type="s:boolean"/>
<s:element minOccurs="1" maxOccurs="1" name="CanApprove" type="s:boolean"/>
```
source: https://api.tipalti.com/v5/PayerFunctions.asmx?WSDL

- `is_paid_manually` and `can_approve` are required fields

Also, update documentations URLs on the docs.